### PR TITLE
Change minSDKVersion in starter phone app from 29 to 28 to match clas…

### DIFF
--- a/PhoneStarter/build.gradle
+++ b/PhoneStarter/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.phoneapp"
-        minSdkVersion 29
+        minSdkVersion 28
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
…s API level

Took me a minute to figure out where this setting was when I found I couldn't run the phone app since the project wasn't set to use API 28. I figure we might as well change it so we don't have to worry about it in future versions of the starter app :)